### PR TITLE
Enable FQDN for tests

### DIFF
--- a/docs/test_coverage.md
+++ b/docs/test_coverage.md
@@ -1,0 +1,19 @@
+# Test Coverage
+
+Aquilon's test suite can generate code coverage reports using the standard `coverage.py` library.
+
+Run the tests with coverage enabled:
+
+```bash
+python tests/runtests.py --config=tests/unittest.conf --no-interactive --coverage
+```
+
+Ensure the machine's fully qualified hostname resolves locally before running
+the command:
+
+```bash
+grep -q $(hostname) /etc/hosts || \
+    echo "127.0.0.1 $(hostname).local" >> /etc/hosts
+```
+
+The HTML and XML reports will be written under `logs/coverage` by default.

--- a/docs/test_coverage.md
+++ b/docs/test_coverage.md
@@ -12,8 +12,7 @@ Ensure the machine's fully qualified hostname resolves locally before running
 the command:
 
 ```bash
-grep -q $(hostname) /etc/hosts || \
-    echo "127.0.0.1 $(hostname).local" >> /etc/hosts
-```
+grep -qE "$(hostname)(\.local)?$" /etc/hosts || \
+    echo "127.0.0.1 $(hostname) $(hostname).local" >> /etc/hosts
 
 The HTML and XML reports will be written under `logs/coverage` by default.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 coverage
 python-dateutil
 ipaddress
-lxml
+lxml>=4.9.2
 Mako
 psycopg2-binary>=2.8.3
 six>=1.7.3
@@ -16,3 +16,4 @@ coloredlogs
 protobuf
 requests
 requests_cache
+orjson

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 coverage
 python-dateutil
 ipaddress
-lxml>=4.9.2
+lxml>=4.9.2,<5.0.0
 Mako
 psycopg2-binary>=2.8.3
 six>=1.7.3

--- a/tests/unittest.conf
+++ b/tests/unittest.conf
@@ -28,19 +28,19 @@ urls = http://localhost:8900
 
 [broker]
 authorization_rules = %(srcdir)s/tests/unittest_authorization.conf
-servername = %(hostname)s.local
+servername = %(hostname)s
 umask = 0022
 kncport = 6912
 openport = 6913
 git_port = 9429
 # Testing the case when bind_address is set is more interesting than when it's not...
 # It would be better to use localhost (to make sure nothing goes out to the wire), but that would make Kerberos unhappy
-bind_address = %(hostname)s.local
+bind_address = %(hostname)s
 run_git_daemon = True
 git_author_name = %(user)s
-git_author_email = %(user)s@%(hostname)s.local
+git_author_email = %(user)s@%(hostname)s
 git_committer_name = %(user)s
-git_committer_email = %(user)s@%(hostname)s.local
+git_committer_email = %(user)s@%(hostname)s
 trash_branch = unittest_trash
 server_notifications = utnotify
 client_notifications = False

--- a/tests/unittest.conf
+++ b/tests/unittest.conf
@@ -28,19 +28,19 @@ urls = http://localhost:8900
 
 [broker]
 authorization_rules = %(srcdir)s/tests/unittest_authorization.conf
-servername = %(hostname)s
+servername = %(hostname)s.local
 umask = 0022
 kncport = 6912
 openport = 6913
 git_port = 9429
 # Testing the case when bind_address is set is more interesting than when it's not...
 # It would be better to use localhost (to make sure nothing goes out to the wire), but that would make Kerberos unhappy
-bind_address = %(hostname)s
+bind_address = %(hostname)s.local
 run_git_daemon = True
 git_author_name = %(user)s
-git_author_email = %(user)s@%(hostname)s
+git_author_email = %(user)s@%(hostname)s.local
 git_committer_name = %(user)s
-git_committer_email = %(user)s@%(hostname)s
+git_committer_email = %(user)s@%(hostname)s.local
 trash_branch = unittest_trash
 server_notifications = utnotify
 client_notifications = False


### PR DESCRIPTION
## Summary
- update test configuration to use a fully qualified hostname
- document how to run coverage
- add orjson dependency
- fix hostname interpolation in the test config
- set local hostname for tests
- pin lxml dependency
- set hostname for coverage
- mention /etc/hosts command before running coverage
- fix hostname recursion
- remove hostname interpolation

## Testing
- `/root/.pyenv/versions/3.10.17/bin/pre-commit run --files tests/unittest.conf` *(skipped: no files to check)*
- `python tests/runtests.py --config=tests/unittest.conf --no-interactive` *(failed: ModuleNotFoundError: No module named 'six')*

------
https://chatgpt.com/codex/tasks/task_e_6851e3a62fa48322aa2a1042983e90b2

## Summary by Sourcery

Enable fully qualified hostnames in the test suite, update dependencies, and add documentation for running coverage reports

Enhancements:
- Use `.local` suffix for servername, bind_address, and Git email settings in test configuration
- Pin lxml dependency to version 4.9.2 or later
- Add orjson as a test dependency

Documentation:
- Add documentation for generating and locating test coverage reports in docs/test_coverage.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added instructions for generating test coverage reports, including usage of coverage tools and required environment setup.

- **Chores**
  - Updated dependency requirements: specified a minimum version for lxml and added orjson.
  - Adjusted test configuration to use fully qualified hostnames with the ".local" suffix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->